### PR TITLE
feat: enable web playback fallback when no Spotify device active

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,10 +53,11 @@ app.get('/', (req, res) => {
       title: 'Spootify Web - Connexion'
     });
   }
-  
+
   res.render('dashboard', {
     title: 'Spootify Web - Dashboard',
-    user: req.session.user || null
+    user: req.session.user || null,
+    spotifyToken: req.session.accessToken || ''
   });
 });
 

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -604,6 +604,10 @@
     <audio id="local-audio-player" preload="metadata"></audio>
 
     <script src="/socket.io/socket.io.js"></script>
+    <script src="https://sdk.scdn.co/spotify-player.js"></script>
+    <script>
+        window.spotifyToken = "<%= spotifyToken || '' %>";
+    </script>
     <script src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- pass Spotify token to dashboard and load Web Playback SDK
- add Web Playback initialization and device checks in client
- start liked tracks via web player when no active device